### PR TITLE
Use frozen_string_literal in class Command

### DIFF
--- a/lib/progeny/command.rb
+++ b/lib/progeny/command.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Progeny
   # Progeny::Command includes logic for executing child processes and
   # reading/writing from their standard input, output, and error streams. It's
@@ -228,7 +229,7 @@ module Progeny
     #   exceeds the amount specified by the max argument.
     def read_and_write(input, stdin, stdout, stderr, timeout=nil, max=nil)
       max = nil if max && max <= 0
-      @out, @err = '', ''
+      @out, @err = +'', +''
 
       # force all string and IO encodings to BINARY under 1.9 for now
       if @out.respond_to?(:force_encoding) and stdin.respond_to?(:set_encoding)


### PR DESCRIPTION
## Description
Adds `frozen_string_literal: true` magic comment to enable frozen string literals on `Progeny::Command`. 
Also uses `+''` to create mutable strings for `@out` and `@err`.

## Context
There was a deprecation warning for chilled strings merged recently in Ruby: https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

And with that we started to see the following warnings on progeny:
```
 /vendor/gems/3.4.0/ruby/3.4.0+0/gems/progeny-0.2.0/lib/progeny/command.rb:238:in 'String#force_encoding':
 /vendor/gems/3.4.0/ruby/3.4.0+0/gems/progeny-0.2.0/lib/progeny/command.rb:239:in 'String#force_encoding':
 ```